### PR TITLE
added uninstall option to gardener scripts and allowed for multiple sourcing of init.sh

### DIFF
--- a/components/cert/deploy
+++ b/components/cert/deploy
@@ -14,16 +14,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-python generate-values.py > "$COMPONENT_STATE_HOME/csr.json"
+if [ $# -gt 1 ] && [ $2 == "-u" -o $2 == "--uninstall" ]; then # uninstall cert
+    rm -rf $COMPONENT_STATE_HOME
+else # install cert
+    python generate-values.py > "$COMPONENT_STATE_HOME/csr.json"
 
-if [ ! -f "$COMPONENT_STATE_HOME/ca-config.json" ] ; then
-    cp "${COMPONENT_TEMPLATE_HOME}/ca-config.json" "$COMPONENT_STATE_HOME/ca-config.json"
-fi
+    if [ ! -f "$COMPONENT_STATE_HOME/ca-config.json" ] ; then
+        cp "${COMPONENT_TEMPLATE_HOME}/ca-config.json" "$COMPONENT_STATE_HOME/ca-config.json"
+    fi
 
-if [ ! -f ${COMPONENT_STATE_HOME}/tls.crt ] ; then
-    cfssl gencert -ca=${KUBIFY_STATE_PATH}/gen/assets/tls/ca.crt -ca-key=${KUBIFY_STATE_PATH}/gen/assets/tls/ca.key -config=${COMPONENT_STATE_HOME}/ca-config.json -profile=server ${COMPONENT_STATE_HOME}/csr.json | cfssljson -bare server
-    mv ${COMPONENT_TEMPLATE_HOME}/server-key.pem ${COMPONENT_STATE_HOME}/tls.key
-    cat ${COMPONENT_TEMPLATE_HOME}/server.pem ${KUBIFY_STATE_PATH}/gen/assets/tls/ca.crt >${COMPONENT_STATE_HOME}/tls.crt
-    rm ${COMPONENT_TEMPLATE_HOME}/server.pem
-    mv ${COMPONENT_TEMPLATE_HOME}/server.csr ${COMPONENT_STATE_HOME}/tls.csr
+    if [ ! -f ${COMPONENT_STATE_HOME}/tls.crt ] ; then
+        cfssl gencert -ca=${KUBIFY_STATE_PATH}/gen/assets/tls/ca.crt -ca-key=${KUBIFY_STATE_PATH}/gen/assets/tls/ca.key -config=${COMPONENT_STATE_HOME}/ca-config.json -profile=server ${COMPONENT_STATE_HOME}/csr.json | cfssljson -bare server
+        mv ${COMPONENT_TEMPLATE_HOME}/server-key.pem ${COMPONENT_STATE_HOME}/tls.key
+        cat ${COMPONENT_TEMPLATE_HOME}/server.pem ${KUBIFY_STATE_PATH}/gen/assets/tls/ca.crt >${COMPONENT_STATE_HOME}/tls.crt
+        rm ${COMPONENT_TEMPLATE_HOME}/server.pem
+        mv ${COMPONENT_TEMPLATE_HOME}/server.csr ${COMPONENT_STATE_HOME}/tls.csr
+    fi
 fi

--- a/components/dashboard/deploy
+++ b/components/dashboard/deploy
@@ -14,21 +14,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-dashboard_config="$(read_landscape_config '.charts[] | select(.name=="dashboard")')"
-dashboard_repo_path=${LANDSCAPE_HOME}/"dashboard"
+if [ $# -gt 1 ] && [ $2 == "-u" -o $2 == "--uninstall" ]; then # uninstall dashboard
+  helm delete --purge dashboard 
+  rm -rf $COMPONENT_STATE_HOME
+else # install dashboard
+  dashboard_config="$(read_landscape_config '.charts[] | select(.name=="dashboard")')"
+  dashboard_repo_path=${LANDSCAPE_HOME}/"dashboard"
 
-# render identity helm chart values
-python generate-values.py \
-  --dashboard-repo-path="$dashboard_repo_path" \
-  --tls-crt-path="$LANDSCAPE_STATE_HOME/cert/tls.crt" \
-  --tls-key-path="$LANDSCAPE_STATE_HOME/cert/tls.key" \
-  > "$COMPONENT_STATE_HOME/values.yaml"
+  # render identity helm chart values
+  python generate-values.py \
+    --dashboard-repo-path="$dashboard_repo_path" \
+    --tls-crt-path="$LANDSCAPE_STATE_HOME/cert/tls.crt" \
+    --tls-key-path="$LANDSCAPE_STATE_HOME/cert/tls.key" \
+    > "$COMPONENT_STATE_HOME/values.yaml"
 
-# install or upgrade identity
-helm upgrade --install \
-  --force \
-  --wait \
-  --values "$COMPONENT_STATE_HOME/values.yaml" \
-  --namespace garden \
-  dashboard \
-  "$dashboard_repo_path/$(jq -r '.path' <<< "$dashboard_config")"
+  # install or upgrade identity
+  helm upgrade --install \
+    --force \
+    --wait \
+    --values "$COMPONENT_STATE_HOME/values.yaml" \
+    --namespace garden \
+    dashboard \
+    "$dashboard_repo_path/$(jq -r '.path' <<< "$dashboard_config")"
+fi

--- a/components/deploy.sh
+++ b/components/deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash 
 #
 # Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 #
@@ -74,4 +74,4 @@ stack_new component_state_home_stack
 stack_new component_template_home_stack
 
 calc_paths $1
-call_deploy $1
+call_deploy $@

--- a/components/gardener/deploy
+++ b/components/gardener/deploy
@@ -14,51 +14,59 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# generate Gardener API server TLS certificate if not yet done
-path_tls="$COMPONENT_TEMPLATE_HOME/tls"
-cert_names="gardener-apiserver"
-if [[ ! -f "$COMPONENT_STATE_HOME/tls/$cert_names-tls.pem" ]]; then
-  mkdir -p "$COMPONENT_STATE_HOME/tls"
-  cfssl gencert \
-    -profile=server \
-    -ca="$LANDSCAPE_ACTIVE_CLUSTER_REPO_PATH/gen/assets/tls/ca.crt" \
-    -ca-key="$LANDSCAPE_ACTIVE_CLUSTER_REPO_PATH/gen/assets/tls/ca.key" \
-    -config="$path_tls/ca-config.json" \
-    "$path_tls/gardener-apiserver-config.json" | cfssljson -bare "$COMPONENT_STATE_HOME/tls/$cert_names-tls"
-fi
-
-# render gardener helm chart values
-python generate-values.py \
-  --gardener-repo-path="$GARDENER_REPO_PATH" \
-  --etcd-server="$(kubectl -n kube-system get svc etcd-service -o jsonpath --template={.spec.clusterIP}:{.spec.ports[0].port})" \
-  > "$COMPONENT_STATE_HOME/values.yaml"
-
-kubectl config view
-kubectl config current-context 
-
-gardener_config="$(read_landscape_config .charts[0])"
-
-# install or upgrade gardener
-helm upgrade --install \
-  --force \
-  --wait \
-  --values "$COMPONENT_STATE_HOME/values.yaml" \
-  --namespace garden \
-  gardener \
-  "$GARDENER_REPO_PATH/$(jq -r '.path' <<< "$gardener_config")"
-
-# wait for api server extension to become available
-max_retry_time=300
-retry_stop=$(($(date +%s) + max_retry_time))
-success=false
-while [[ $(date +%s) -lt $retry_stop ]]; do
-  sleep 1
-  if kubectl get shoots &> /dev/null; then
-    success=true
-    break;
+if [ $# -gt 1 ] && [ $2 == "-u" -o $2 == "--uninstall" ]; then # uninstall gardener
+  helm delete --purge gardener
+  kubectl -n garden delete statefulset prometheus
+  kubectl -n garden delete service prometheus-web
+  rm -rf ~/.kube # clear kubectl cache to prevent error on next call
+  rm -rf $COMPONENT_STATE_HOME
+else # install gardener
+  # generate Gardener API server TLS certificate if not yet done
+  path_tls="$COMPONENT_TEMPLATE_HOME/tls"
+  cert_names="gardener-apiserver"
+  if [[ ! -f "$COMPONENT_STATE_HOME/tls/$cert_names-tls.pem" ]]; then
+    mkdir -p "$COMPONENT_STATE_HOME/tls"
+    cfssl gencert \
+      -profile=server \
+      -ca="$LANDSCAPE_ACTIVE_CLUSTER_REPO_PATH/gen/assets/tls/ca.crt" \
+      -ca-key="$LANDSCAPE_ACTIVE_CLUSTER_REPO_PATH/gen/assets/tls/ca.key" \
+      -config="$path_tls/ca-config.json" \
+      "$path_tls/gardener-apiserver-config.json" | cfssljson -bare "$COMPONENT_STATE_HOME/tls/$cert_names-tls"
   fi
-  echo -e "$(debug Gardener API server not yet reachable. Waiting...)"
-done
-if ! $success; then
-  fail "Gardener API server did not become reachable within $max_retry_time seconds!"
+
+  # render gardener helm chart values
+  python generate-values.py \
+    --gardener-repo-path="$GARDENER_REPO_PATH" \
+    --etcd-server="$(kubectl -n kube-system get svc etcd-service -o jsonpath --template={.spec.clusterIP}:{.spec.ports[0].port})" \
+    > "$COMPONENT_STATE_HOME/values.yaml"
+
+  kubectl config view
+  kubectl config current-context 
+
+  gardener_config="$(read_landscape_config .charts[0])"
+
+  # install or upgrade gardener
+  helm upgrade --install \
+    --force \
+    --wait \
+    --values "$COMPONENT_STATE_HOME/values.yaml" \
+    --namespace garden \
+    gardener \
+    "$GARDENER_REPO_PATH/$(jq -r '.path' <<< "$gardener_config")"
+
+  # wait for api server extension to become available
+  max_retry_time=300
+  retry_stop=$(($(date +%s) + max_retry_time))
+  success=false
+  while [[ $(date +%s) -lt $retry_stop ]]; do
+    sleep 1
+    if kubectl get shoots &> /dev/null; then
+      success=true
+      break;
+    fi
+    echo -e "$(debug Gardener API server not yet reachable. Waiting...)"
+  done
+  if ! $success; then
+    fail "Gardener API server did not become reachable within $max_retry_time seconds!"
+  fi
 fi

--- a/components/helm-tiller/deploy
+++ b/components/helm-tiller/deploy
@@ -14,10 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# initialize helm
-kubectl -n kube-system get serviceaccount tiller || \
-  kubectl -n kube-system create serviceaccount tiller
-kubectl get clusterrolebinding tiller || \
-  kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
-helm init --upgrade --wait --service-account tiller
+if [ $# -gt 1 ] && [ $2 == "-u" -o $2 == "--uninstall" ]; then # uninstall tiller
+  kubectl -n kube-system delete deployment tiller-deploy
+  kubectl delete clusterrolebinding tiller
+  kubectl -n kube-system delete serviceaccount tiller
+  kubectl -n kube-system delete service tiller-deploy
+  rm -rf $COMPONENT_STATE_HOME
+else # initialize helm
+  kubectl -n kube-system get serviceaccount tiller || \
+    kubectl -n kube-system create serviceaccount tiller
+  kubectl get clusterrolebinding tiller || \
+    kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
+  helm init --upgrade --wait --service-account tiller
+fi
 

--- a/components/identity/deploy
+++ b/components/identity/deploy
@@ -22,39 +22,44 @@ function generate_random() {
 identity_config="$(read_landscape_config '.charts[] | select(.name=="identity")')"
 identity_repo_path="${DASHBOARD_REPO_PATH}"
 
-# check passwords kubectlClientSecret, 
-# (generate if needed, do not overwrite)
+if [ $# -gt 1 ] && [ $2 == "-u" -o $2 == "--uninstall" ]; then # uninstall identity
+    helm delete --purge identity
+    rm -rf $COMPONENT_STATE_HOME
+else # install identity
+    # check passwords kubectlClientSecret, 
+    # (generate if needed, do not overwrite)
 
-if [ ! -f "${COMPONENT_STATE_HOME}/kubectlClientSecret" ] ; then
-    kubectlClientSecret="$(read_landscape_config '.charts[] | select(.name=="identity") | .values.kubectlClientSecret')"
-    if [ -z $kubectlClientSecret -o "$kubectlClientSecret" == "null" ] ; then
-        generate_random > "${COMPONENT_STATE_HOME}/kubectlClientSecret"
-    else
-        echo -n $kubectlClientSecret > "${COMPONENT_STATE_HOME}/kubectlClientSecret"
+    if [ ! -f "${COMPONENT_STATE_HOME}/kubectlClientSecret" ] ; then
+        kubectlClientSecret="$(read_landscape_config '.charts[] | select(.name=="identity") | .values.kubectlClientSecret')"
+        if [ -z $kubectlClientSecret -o "$kubectlClientSecret" == "null" ] ; then
+            generate_random > "${COMPONENT_STATE_HOME}/kubectlClientSecret"
+        else
+            echo -n $kubectlClientSecret > "${COMPONENT_STATE_HOME}/kubectlClientSecret"
+        fi
     fi
-fi
 
-if [ ! -f "${COMPONENT_STATE_HOME}/dashboardClientSecret" ] ; then
-    dashboardClientSecret="$(read_landscape_config '.charts[] | select(.name=="identity") | .values.dashboardClientSecret')"
-    if [ -z $dashboardClientSecret -o "$dashboardClientSecret" == "null" ] ; then
-        generate_random > "${COMPONENT_STATE_HOME}/dashboardClientSecret"
-    else
-        echo -n $dashboardClientSecret > "${COMPONENT_STATE_HOME}/dashboardClientSecret"
+    if [ ! -f "${COMPONENT_STATE_HOME}/dashboardClientSecret" ] ; then
+        dashboardClientSecret="$(read_landscape_config '.charts[] | select(.name=="identity") | .values.dashboardClientSecret')"
+        if [ -z $dashboardClientSecret -o "$dashboardClientSecret" == "null" ] ; then
+            generate_random > "${COMPONENT_STATE_HOME}/dashboardClientSecret"
+        else
+            echo -n $dashboardClientSecret > "${COMPONENT_STATE_HOME}/dashboardClientSecret"
+        fi
     fi
+
+
+    # render identity helm chart values
+    python generate-values.py \
+    --tls-crt-path="$LANDSCAPE_STATE_HOME/cert/tls.crt" \
+    --tls-key-path="$LANDSCAPE_STATE_HOME/cert/tls.key" \
+    > "$COMPONENT_STATE_HOME/values.yaml"
+
+    # install or upgrade identity
+    helm upgrade --install \
+    --force \
+    --wait \
+    --values "$COMPONENT_STATE_HOME/values.yaml" \
+    --namespace kube-system \
+    identity \
+    "$identity_repo_path/$(jq -r '.path' <<< "$identity_config")"
 fi
-
-
-# render identity helm chart values
-python generate-values.py \
-  --tls-crt-path="$LANDSCAPE_STATE_HOME/cert/tls.crt" \
-  --tls-key-path="$LANDSCAPE_STATE_HOME/cert/tls.key" \
-  > "$COMPONENT_STATE_HOME/values.yaml"
-
-# install or upgrade identity
-helm upgrade --install \
-  --force \
-  --wait \
-  --values "$COMPONENT_STATE_HOME/values.yaml" \
-  --namespace kube-system \
-  identity \
-  "$identity_repo_path/$(jq -r '.path' <<< "$identity_config")"

--- a/components/kubify/wait_for_cluster.sh
+++ b/components/kubify/wait_for_cluster.sh
@@ -20,6 +20,7 @@ if [ $# -lt 1 ] || [ $1 != "-nw" -a $1 != "--no-wait" ]; then # allow skipping t
   sleep 300
 fi
 
+echo "Waiting time is up. Now trying to reach the cluster ..."
 max_retry_time=900
 retry_stop=$(($(date +%s) + max_retry_time))
 success=false

--- a/components/kubify/wait_for_cluster.sh
+++ b/components/kubify/wait_for_cluster.sh
@@ -16,8 +16,8 @@
 
 echo "Waiting for the cluster ..."
 if [ $# -lt 1 ] || [ $1 != "-nw" -a $1 != "--no-wait" ]; then # allow skipping the time for testing purposes
-  echo "Give the cluster some time to come up ... (waiting for 5 minutes)"
-  sleep 300
+  echo "Give the cluster some time to come up ... (waiting for 1 minute)"
+  sleep 60
 fi
 
 echo "Waiting time is up. Now trying to reach the cluster ..."

--- a/components/seed-config/deploy
+++ b/components/seed-config/deploy
@@ -14,15 +14,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-for i in ${COMPONENT_TEMPLATE_HOME}/${CLOUD_VARIANT}/*.tmpl ; do
-    filet=$(basename $i)
-    file=${filet::-5}
-    mako-render $i > ${COMPONENT_STATE_HOME}/$file
-done
+if [ $# -gt 1 ] && [ $2 == "-u" -o $2 == "--uninstall" ]; then # uninstall seed-config
+    for i in $(ls -r ${COMPONENT_STATE_HOME}/*.yaml); do # iterate over files in reverse order
+        kubectl delete -f $i --ignore-not-found
+    done
+    rm -rf $COMPONENT_STATE_HOME
+else # install seed-config
+    for i in ${COMPONENT_TEMPLATE_HOME}/${CLOUD_VARIANT}/*.tmpl ; do
+        filet=$(basename $i)
+        file=${filet::-5}
+        mako-render $i > ${COMPONENT_STATE_HOME}/$file
+    done
 
-# deploy
+    # deploy
 
-for i in ${COMPONENT_STATE_HOME}/*.yaml ; do
-    echo deploying $i
-    kubectl apply -f $i
-done
+    for i in ${COMPONENT_STATE_HOME}/*.yaml ; do
+        echo deploying $i
+        kubectl apply -f $i
+    done
+fi

--- a/deploy_gardener.sh
+++ b/deploy_gardener.sh
@@ -9,7 +9,7 @@ echo "Setting up the cluster ..."
 # should already have happened
 # source setup/init.sh
 
-cd components
+pushd "$LANDSCAPE_COMPONENTS_HOME" 1> /dev/null
 
 # kubify - not yet automated
 #./deploy.sh kubify
@@ -35,5 +35,6 @@ cd components
 # certmanager - there's an extra script for that
 #./deploy.sh certmanager
 
-cd ..
+popd 1> /dev/null
+
 echo "Gardener successfully deployed!"

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -2,4 +2,4 @@
 
 # Run the docker container with interactive shell, cd to the mounted folder, and source the init.sh file
 # the "&& bash" keeps the interactive mode of the docker container alive
-docker run -it -v $(pwd)/..:/landscape -w /landscape gardener_landscape bash -c "source ./setup/init.sh && bash"
+docker run -it -v $(pwd)/..:/landscape -w /landscape/setup gardener_landscape bash -c "source ./init.sh && bash"

--- a/init.sh
+++ b/init.sh
@@ -14,9 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# preserve original path
-export SETUP_NON_WRAPPED_PATH="$PATH"
-
 # landscape home is one level higher
 landscape_homet="$(readlink -f "${BASH_SOURCE[0]}")"
 landscape_homev="$(dirname ${landscape_homet})"
@@ -38,7 +35,12 @@ export LANDSCAPE_STATE_HOME="$LANDSCAPE_HOME/state"
 export LANDSCAPE_COMPONENTS_HOME="$LANDSCAPE_HOME/setup/components"
 export LANDSCAPE_EXPORT_HOME="$LANDSCAPE_HOME/export"
 
-export PATH=${SETUP_REPO_PATH}/bin:$PATH
+# only do this once!
+if [ -z $SETUP_NON_WRAPPED_PATH ]; then
+    # preserve original path
+    export SETUP_NON_WRAPPED_PATH="$PATH"
+    export PATH=${SETUP_REPO_PATH}/bin:$PATH
+fi
 
 export LANDSCAPE_NAME="$(grep -m 1 -F "domain_name:" "$LANDSCAPE_HOME/landscape.yaml" | awk '{ print $2 }')"
 

--- a/undeploy_gardener.sh
+++ b/undeploy_gardener.sh
@@ -1,0 +1,41 @@
+#!/bin/bash -eu
+#
+# Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "Removing components..."
+
+pushd "$LANDSCAPE_COMPONENTS_HOME" 1> /dev/null
+
+# dashboard 
+./deploy.sh dashboard --uninstall
+
+# identity
+./deploy.sh identity --uninstall
+
+# seed-config
+./deploy.sh seed-config --uninstall
+
+# gardener
+./deploy.sh gardener --uninstall
+
+# helm-tiller
+./deploy.sh helm-tiller --uninstall
+
+# certificates
+./deploy.sh cert --uninstall
+
+popd 1> /dev/null
+
+echo "Uninstall complete!"


### PR DESCRIPTION
Calling "components/deploy.sh <component> --uninstall" should now remove everything that came with the component. This option exists for all components except the certmanager at the moment. Take care to delete the components in reverse order - the last one installed should be the first to uninstall. 
Furthermore, sourcing init.sh multiple times could mess up the PATH variable and break some commands (e.g. helm) - this shouldn't happen anymore.