### PR TITLE
0.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,6 @@ RUN apt-get update && apt-get install -y jq gnupg2 python python-mako curl \
     unzip spiff_linux_amd64.zip && mv spiff /usr/local/bin && rm -rf spiff_linux_amd64.zip && \
     echo "\nsource <(/usr/local/bin/kubectl completion bash) \nsource /etc/bash_completion" >> ~/.bashrc && \
     echo "\n\nTERM=xterm-256color" >> ~/.bashrc && \
+    echo "alias k='kubectl' \nalias ks='kubectl -n kube-system' \nalias kg='kubectl -n garden' \nalias ka='kubectl get --all-namespaces'" >> ~/.bash_aliases && \
+    sed -i -e "s/#force_color_prompt=yes/force_color_prompt=yes/g" ~/.bashrc && \
     chmod 755 /usr/local/bin/*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,332 @@
 # Gardener Setup Scripts
 
-Refer to the documentation in project [landscape-setup-template](https://github.com/gardener/landscape-setup-template).
+This is the installation manual for a simple Gardener setup. It is part of the [landscape-setup-template](https://github.com/gardener/landscape-setup-template) project. You can find further information there.
+
+
+# Prerequisites
+
+Before getting started make sure you have the following at hand:
+
+* You need a cloud account with sufficient quota to set up a Kubernetes cluster
+with a couple of VMs. **This project currently supports AWS and Openstack.**
+* A Linux machine (virtual machine is fine) or a Mac with basic tools such as a
+git client and the Docker runtime installed.
+
+
+# Gardener Installation
+
+Follow these steps to install Gardener. Do not proceed to the next
+step in case of errors.
+
+
+## TLDR
+If you are already familiar with the installation procedure and just want a short 
+summary of the commands you have to use, here it is:
+
+```
+# setup
+git clone  --recursive https://github.com/gardener/landscape-setup-template.git landscape
+cd landscape/setup
+./docker_run.sh
+./deploy_kubify.sh
+./deploy_gardener.sh
+
+# optional: certmanager
+cd components
+./deploy.sh certmanager
+
+# -------------------------------------------------------------------
+
+# teardown
+cd /landscape
+k8s/bin/tf destroy -force
+setup/cleanup.sh
+```
+
+
+## Step 1: Clone the Repositories and get Dependencies
+
+Get the `landscape-setup-template` from GitHub and initialize the
+submodules:
+
+```
+git clone  --recursive https://github.com/gardener/landscape-setup-template.git landscape
+cd landscape
+```
+
+This repository will contain all passwords and keys for your landscape.
+You will be in trouble if you loose them so we recommend that you store
+this landscape configuration in a private repository. It might be a good idea to change the
+origin so you do not accidentally publish your secrets to the public template repository.
+
+## Step 2: Configure the Landscape
+
+There is a `landscape_config.yaml` file in the landscape project. This is the only
+file that you need to modify - all other configuration files will be
+derived from this and the `landscape_base.yaml` file. The latter one contains the merging instructions
+as well as technical configurations and it shouldn't be touched unless you know what you are doing. 
+
+## Step 3: Build and Run Docker Container
+
+First, you need to change into the setup folder:
+```
+cd setup
+```
+
+Then run the container:
+
+```
+./docker_run.sh
+```
+
+After this,
+
+* you will be connected to the container via an interactive shell
+* the landscape folder will be mounted in that container
+* your current working directory will be `setup` folder
+* `setup/init.sh` is sourced, meaning
+  * the environment variables will be set
+  * kubectl will be configured to communicate with your cluster
+
+The `docker_run.sh` script searches for the image locally and pulls it from an image repository, if it isn't found. 
+If pulling the image doesn't work - which will probably be the case if the version in the `setup/VERSION` file 
+doesn't match a release version of the setup submodule - you can use the `docker_build.sh` script to build the image locally. 
+
+Most of the scripts need a `landscape.yaml` file, that can be generated from a merge of `landscape_base.yaml` and `landscape_config.yaml`. 
+The `init.sh` script (which is sourced in the `docker_run.sh` script, see above) 
+will do that automatically, if it doesn't already exist. 
+In case you want to overwrite an existing `landscape.yaml` file or generate it manually, you can use this script:
+
+```
+./build_landscape_yaml.sh
+```
+
+## Step 4: Create a Kubernetes Cluster via Kubify
+
+You can use this script to run the cluster setup:
+
+```
+./deploy_kubify.sh
+```
+
+The script will wait some time for the cluster to come up and then partly
+validate that the cluster is ready.
+
+If you get errors during the cluster setup, just try to run the script again.
+
+Once completed the following command should show all deployed pods:
+
+```
+root@c41327633d6d:/landscape# kubectl get pods --all-namespaces
+NAMESPACE       NAME                                                                  READY     STATUS    RESTARTS   AGE
+kube-system     etcd-operator-75dcfcf4f7-xkm4h                                        1/1       Running   0          6m
+kube-system     heapster-c8fb4f746-tvts6                                              2/2       Running   0          2m
+kube-system     kube-apiserver-hcdnc                                                  1/1       Running   0          6m
+[...]
+```
+
+## Step 5-9: Gardener Setup (Automated)
+
+Steps 5-9 are automated. In case you need more control follow
+the instructions below for manually running them.
+
+```
+./deploy_gardener.sh
+```
+
+After successful completion, you can either continue with [step 10 (optional)](#step10), or start using 
+the Gardener (see *[Accessing the Dashboard](#access_dashboard)*).
+
+
+## <a name="access_dashboard"></a>Accessing the Dashboard
+
+After step 9 you will be able to access the Gardener dashboard. This example assumes that 
+your cluster is located at `mycluster.example.org` - just replace that part with 
+whatever you put in the `clusters.dns.domain_name` entry in the `landscape_config.yaml` file.
+
+The `print_dashboard_urls.sh` script constructs both URLs from the domain name given in 
+the `landscape.yaml` file and prints them. It is called automatically at the end of 
+the Gardener deploy script.
+
+First, open `https://identity.ingress.mycluster.example.org`. Your browser will show a warning 
+regarding untrusted self-signed certificates, you need to ignore that warning. 
+You will then see a nearly blank page with some 404 message. 
+If you skip this step, you will still be able to see the dashboard in the next step, 
+but the login button probably won't work. 
+
+Now you can open the dashboard at `https://dashboard.ingress.mycluster.example.org`. Here you 
+need to ignore a similar warning again, then you should see the dashboard. You can login 
+using the options you have specified in the identity chart part of the `landscape_config.yaml`.
+
+
+
+## Step 5-9: Gardener Setup (Manual)
+
+The commands shown below need to be run from within the components 
+directory of the setup folder:
+
+```
+cd /landscape/setup/components
+```
+
+### Step 5: Generate Certificates
+
+These are the self-signed certificates used for the dashboard and
+identity ingresses (if you are on the internet you can later get
+letsencrypt issued certificates).
+
+```
+./deploy.sh cert
+```
+
+### Step 6: Deploy tiller
+
+Tiller is needed to deploy Helm charts in order to deploy Gardener and other needed components
+
+```
+./deploy.sh helm-tiller
+```
+
+### Step 7: Deploy Gardener
+
+Now we can deploy Gardener. If the previous steps were executed successfully
+this should be completed in a couple of seconds.
+
+```
+./deploy.sh gardener
+```
+
+You might see a couple of messages like these:
+
+```
+Gardener API server not yet reachable. Waiting...
+```
+
+while the script waits for the Gardener to start. Once Gardener is up
+when the deployment script finished you can verify the correct setup by
+running the following command:
+
+```
+kubectl get shoots
+No resources found. 
+```
+
+As we do not have a seed cluster yet we cannot create any shoot clusters.
+The Gardener itself is installed in the `garden` namespace:
+
+```
+kubectl get po -n garden
+NAME                                          READY     STATUS    RESTARTS   AGE
+gardener-apiserver-56cc665667-nvrjl           1/1       Running   0          6m
+gardener-controller-manager-5c9f8db55-hfcts   1/1       Running   0          6m
+```
+
+### Step 8: Register Garden Cluster as Seed Cluster
+
+In heterogeneous productive environments one would run Gardener and seed in
+separate clusters but for simplicity and resource consumption
+reasons we will register the Gardener cluster that we have just created also as the seed
+cluster. Make sure that the `seed_config` in the landscape file is correct
+and matches the region that you are using. Keep in mind that image ids differ
+between regions as well.
+
+```
+./deploy.sh seed-config
+```
+
+That's it! If everything went fine you should now be able to create shoot clusters.
+You can start with a sample
+[manifest](https://github.com/gardener/gardener/blob/master/example/shoot-aws.yaml)
+and create a shoot cluster by standard Kubernetes means:
+
+```
+kubectl apply -f shoot-aws.yaml
+```
+
+### Step 9: Install Identity and Dashboard
+
+Creating clusters based on a shoot manifest is quite nice but also a little
+complex. While almost all aspects of a shoot cluster can be configured it can
+be quite difficult for beginners, so go on and install the dashboard:
+
+```
+./deploy.sh identity
+[...]
+./deploy.sh dashboard
+[...]
+```
+
+Now you should be able to open the "Gardener" dashboard and start creating
+shoot clusters. 
+
+
+## Step 10: Apply Valid Certificates (optional)
+
+Ensure that you are in the components directory for installing the certmanager:
+
+```
+cd /landscape/setup/components
+```
+
+Using the Gardener Dashboard with self-signed certificates is awkward and
+some browsers even prevent you from accessing it altogether.
+
+The following command will install the 
+[cert-manager](https://github.com/jetstack/cert-manager) and request valid
+letsencrypt certificates for both the identity and dashboard ingresses:
+
+```
+./deploy.sh certmanager
+```
+
+After one to two minutes valid certificates should be installed.
+
+# Tearing Down the Landscape
+
+Make sure that you delete all shoot clusters prior to tearing down the
+cluster created by Kubify (either by deleting them in the Gardener dashboard 
+or by using the kubectl command). The following command should 
+not return any shoot clusters:
+
+```
+kubectl get shoots --all-namespaces
+No resources found.
+```
+
+There is a [delete-shoot](https://github.com/gardener/gardener/blob/master/hack/delete-shoot)
+script in order to delete shoot clusters.
+
+Next run terraform in order to delete the cluster:
+
+```
+cd /landscape
+k8s/bin/tf destroy
+[...]
+Plan: 0 to add, 0 to change, 170 to destroy.
+
+Do you really want to destroy?
+  Terraform will destroy all your managed infrastructure, as shown above.
+  There is no undo. Only 'yes' will be accepted to confirm.
+
+  Enter a value:
+```
+
+Enter `yes` when you are sure that you want to delete the cluster.
+
+
+# Cleanup
+
+If you have created and destroyed a cluster and want to restart it, there are some files you 
+have to delete to clean up the directory. 
+
+**ATTENTION: Only do this if you are sure the cluster has been completely destroyed!**
+Since this removes the terraform state, an automated deletion of resources won't be possible anymore - 
+you will have to clean up any leftovers manually.
+
+```
+setup/cleanup.sh
+```
+
+This will reset your landscape folder to its initial state.
+
+The script takes an optional "-y" argument to skip the confirmation.

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -eu
+#
+# Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script will delete resources that are left over after teardown of the cluster.
+# DO NOT USE THIS IF YOUR CLUSTER IS STILL ACTIVE!
+
+if [ $# -gt 0 ] && [ $1 == "-y" ]; then
+    confirmed=yes
+else
+    echo "This will delete the terraform state. Be sure the project is completely deleted from the IaaS layer!"
+    echo -n "Are you sure? (yes) "
+    read confirmed
+fi
+if [ "$confirmed" == yes ]; then
+    pushd "$LANDSCAPE_HOME" 1> /dev/null
+    rm -rf variant terraform.tfvars terraform .terraform terraform.tfstate* state state.auto.tfvars structure-version landscape.yaml export .helm gen rollinfo 
+    popd 1> /dev/null
+else
+    echo "Cleanup aborted."
+fi

--- a/components/certmanager/cert-manager-issuer.yaml.tmpl
+++ b/components/certmanager/cert-manager-issuer.yaml.tmpl
@@ -14,7 +14,7 @@ metadata:
 spec:
   acme:
     # The ACME server URL
-    server: https://acme-v01.api.letsencrypt.org/directory
+    server: https://acme-v02.api.letsencrypt.org/directory
     # Email address used for ACME registration
     email: ${email}
     # Name of a secret used to store the ACME account private key

--- a/components/certmanager/deploy
+++ b/components/certmanager/deploy
@@ -14,42 +14,93 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# render issuer file
-mako-render ${COMPONENT_TEMPLATE_HOME}/cert-manager-issuer.yaml.tmpl >${COMPONENT_STATE_HOME}/cert-manager-issuer.yaml
+if [ $# -gt 1 ] && [ $2 == "-u" -o $2 == "--uninstall" ]; then # uninstall certmanager
+    # delete certmanager
+    helm delete --purge cert-manager
 
-# install certificate manger
-helm upgrade --install \
-  --force \
-  --wait \
-  --namespace \
-  certmanager cert-manager stable/cert-manager
+    # check if oicd-ca-file line is already there, add it if not
+    pos=$(kubectl -n kube-system get -o template ds kube-apiserver --template='{{range $i, $elem := (index .spec.template.spec.containers 0).command}}{{if eq $elem "--oidc-ca-file=/etc/kubernetes/secrets/ca.crt"}}{{$i}}{{end}}{{end}}')
+    if [ -z $pos ]; then # line "--oidc-ca-file=/etc/kubernetes/secrets/ca.crt" not found, insert it
+        # find apiserver line to locate patch position
+        pos=$(kubectl -n kube-system get -o template ds kube-apiserver --template='{{range $i, $elem := (index .spec.template.spec.containers 0).command}}{{if eq $elem "apiserver"}}{{$i}}{{end}}{{end}}')
+        if [ -z $pos ]; then
+            if [ $# -gt 3 ] && [ $3 == "--patch-position" ]; then # manually specified patch position
+                pos=$4
+            else
+                fail "Line \"apiserver\" not found in daemonset kube-apiserver! To manually specify the patch position (line below apiserver line), give \"--patch-position <position>\" as additional parameters."
+            fi
+        else 
+            ((pos=$pos+1)) # add 1 to position of apiserver line to compute patch position
+        fi
+    fi
+    # patch line '--oidc-ca-file=/etc/kubernetes/secrets/ca.crt' into kube-apiserver again
+    kubectl -n kube-system patch ds kube-apiserver --type json -p='[{"op": "add", "path": "/spec/template/spec/containers/0/command/'$pos'", "value": "--oidc-ca-file=/etc/kubernetes/secrets/ca.crt"}]'
 
-# install certificate manager issuer
-kubectl apply -f ${COMPONENT_STATE_HOME}/cert-manager-issuer.yaml
+    # patch dashboard and ingress 
+    identity_issuer=$(kubectl get ingress -n kube-system  identity-ingress -o jsonpath="{.metadata.annotations.certmanager\.k8s\.io/cluster-issuer}")
+    if [ "$identity_issuer" = "letsencrypt" ] ; then
+        kubectl -n kube-system patch ingress identity-ingress --type merge \
+            -p="$(cat ${COMPONENT_TEMPLATE_HOME}/issuer-delete-patch.yaml)"
+    fi
+    
+    dashboard_issuer=$(kubectl get ingress -n garden  gardener-dashboard-ingress -o jsonpath="{.metadata.annotations.certmanager\.k8s\.io/cluster-issuer}")
+    if [ "$dashboard_issuer" = "letsencrypt" ] ; then
+        kubectl -n garden patch ingress gardener-dashboard-ingress --type merge \
+            -p="$(cat ${COMPONENT_TEMPLATE_HOME}/issuer-delete-patch.yaml)"
+    fi
 
-# remove existing certificates (they will not be overwritten)
+    # delete letsencrypt secrets
+    kubectl -n garden delete secret gardener-dashboard-tls --ignore-not-found
+    kubectl -n kube-system delete secret identity-tls  --ignore-not-found
 
-kubectl -n garden delete secret gardener-dashboard-tls
-kubectl -n kube-system delete secret identity-tls  
+    # restore certificates by deploying identity and dashboard again
+    # TODO find better solution
+    $LANDSCAPE_COMPONENTS_HOME/deploy.sh identity
+    $LANDSCAPE_COMPONENTS_HOME/deploy.sh dashboard
 
-# patch dashboard and ingress 
-dashboard_issuer=$(kubectl get ingress -n garden  gardener-dashboard-ingress -o jsonpath="{.metadata.annotations.certmanager\.k8s\.io/cluster-issuer}")
-if [ "$dashboard_issuer" != "letsencrypt" ] ; then
-    kubectl -n garden patch ingress gardener-dashboard-ingress \
-         -p="$(cat ${COMPONENT_TEMPLATE_HOME}/issuer-patch.yaml)"
-fi
-
-identity_issuer=$(kubectl get ingress -n kube-system  identity-ingress -o jsonpath="{.metadata.annotations.certmanager\.k8s\.io/cluster-issuer}")
-if [ "$identity_issuer" != "letsencrypt" ] ; then
-    kubectl -n kube-system patch ingress identity-ingress \
-         -p="$(cat ${COMPONENT_TEMPLATE_HOME}/issuer-patch.yaml)"
-fi
-
-# find position of the line '--oidc-ca-file=/etc/kubernetes/secrets/ca.crt' and save the array position of that entry within the yaml to variable
-pos=$(kubectl -n kube-system get -o template ds kube-apiserver --template='{{range $i, $elem := (index .spec.template.spec.containers 0).command}}{{if eq $elem "--oidc-ca-file=/etc/kubernetes/secrets/ca.crt"}}{{$i}}{{end}}{{end}}')
-if [ $pos ]; then
-    # delete that entry
-    kubectl -n kube-system patch ds kube-apiserver --type json -p='[{"op": "remove", "path": "/spec/template/spec/containers/0/command/'$pos'"}]'
+    # delete certmanager stuff
+    kubectl delete clusterissuer --all
+    kubectl -n certmanager delete secret --all
+    kubectl delete ns certmanager
 else
-    echo "INFO: Line '--oidc-ca-file=/etc/kubernetes/secrets/ca.crt' not found in daemonset kube-apiserver."
+    # render issuer file
+    mako-render ${COMPONENT_TEMPLATE_HOME}/cert-manager-issuer.yaml.tmpl >${COMPONENT_STATE_HOME}/cert-manager-issuer.yaml
+
+    # install certificate manger
+    helm upgrade --install \
+    --force \
+    --wait \
+    --namespace \
+    certmanager cert-manager stable/cert-manager \
+    --version v0.3.0
+
+    # install certificate manager issuer
+    kubectl apply -f ${COMPONENT_STATE_HOME}/cert-manager-issuer.yaml
+
+    # remove existing certificates (they will not be overwritten)
+
+    kubectl -n garden delete secret gardener-dashboard-tls
+    kubectl -n kube-system delete secret identity-tls  
+
+    # patch dashboard and ingress 
+    dashboard_issuer=$(kubectl get ingress -n garden  gardener-dashboard-ingress -o jsonpath="{.metadata.annotations.certmanager\.k8s\.io/cluster-issuer}")
+    if [ "$dashboard_issuer" != "letsencrypt" ] ; then
+        kubectl -n garden patch ingress gardener-dashboard-ingress \
+            -p="$(cat ${COMPONENT_TEMPLATE_HOME}/issuer-patch.yaml)"
+    fi
+
+    identity_issuer=$(kubectl get ingress -n kube-system  identity-ingress -o jsonpath="{.metadata.annotations.certmanager\.k8s\.io/cluster-issuer}")
+    if [ "$identity_issuer" != "letsencrypt" ] ; then
+        kubectl -n kube-system patch ingress identity-ingress \
+            -p="$(cat ${COMPONENT_TEMPLATE_HOME}/issuer-patch.yaml)"
+    fi
+
+    # find position of the line '--oidc-ca-file=/etc/kubernetes/secrets/ca.crt' and save the array position of that entry within the yaml to variable
+    pos=$(kubectl -n kube-system get -o template ds kube-apiserver --template='{{range $i, $elem := (index .spec.template.spec.containers 0).command}}{{if eq $elem "--oidc-ca-file=/etc/kubernetes/secrets/ca.crt"}}{{$i}}{{end}}{{end}}')
+    if [ $pos ]; then
+        # delete that entry
+        kubectl -n kube-system patch ds kube-apiserver --type json -p='[{"op": "remove", "path": "/spec/template/spec/containers/0/command/'$pos'"}]'
+    else
+        echo "INFO: Line '--oidc-ca-file=/etc/kubernetes/secrets/ca.crt' not found in daemonset kube-apiserver."
+    fi
 fi

--- a/components/certmanager/issuer-delete-patch.yaml
+++ b/components/certmanager/issuer-delete-patch.yaml
@@ -1,0 +1,3 @@
+metadata:
+  annotations:
+    certmanager.k8s.io/cluster-issuer: null

--- a/deploy_gardener.sh
+++ b/deploy_gardener.sh
@@ -50,3 +50,5 @@ pushd "$LANDSCAPE_COMPONENTS_HOME" 1> /dev/null
 popd 1> /dev/null
 
 echo "Gardener successfully deployed!"
+echo ""
+$SETUP_REPO_PATH/print_dashboard_urls.sh

--- a/print_dashboard_urls.sh
+++ b/print_dashboard_urls.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+#
+# Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script takes the domain name from the landscape.yaml file
+# and prints the identity and dashboard urls generated from it.
+
+CLUSTER_DOMAIN="$(yaml2json < $LANDSCAPE_CONFIG | jq -r .clusters.dns.domain_name)"
+echo "https://identity.ingress.$CLUSTER_DOMAIN"
+echo "https://dashboard.ingress.$CLUSTER_DOMAIN"


### PR DESCRIPTION
This adds some utility and nice-to-have features to the setup scripts:

- kubectl aliases (ks, kg, ka)
- after gardener deployment, identity/dashboard links are printed
- colored bash prompt in docker container 
- cleanup script for resetting the project

The readme has been splitted to keep the documentation close to the code. The landscape-setup-template project (contained all the readme before) now only contains some general information on the project. The installation procedure part has been moved to this project.