### PR TITLE
use american english for pipeline definition

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -4,7 +4,7 @@ gardener-setup-release-and-image:
     traits:
       version:
         preprocess:
-          'finalise'
+          'finalize'
       publish:
         dockerimages:
           gardener-setup:
@@ -33,7 +33,7 @@ gardener-setup-release:
     traits:
       version:
         preprocess:
-          'finalise'
+          'finalize'
     repo:
       trigger: false
     steps: ~


### PR DESCRIPTION
Users expect to write american english in pipeline definitions.
Therefore rename "finalise" to "finalize"