### PR TITLE
Fix certmanager deploy on single master setup

### DIFF
--- a/components/certmanager/bootstrap_apiserver.sh
+++ b/components/certmanager/bootstrap_apiserver.sh
@@ -1,0 +1,59 @@
+#!/bin/bash -eu
+#
+# Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+getIP()
+{
+  local o
+  o=$(terraform output $1 2>/dev/null)
+  {
+    no=$2
+    while read a; do
+      if [ -n "$o" ]; then
+        if [ $no -eq 0 ]; then
+          echo ${a%%,}
+          return 0
+        fi
+        no=$((no-1))
+      fi
+    done
+    return 1
+  } <<<"$o"
+}
+
+doSSH() {
+    # do ssh, ignore unknown hosts, don't save hosts, suppress warnings about saving hosts
+    ssh -i $pem -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o "ProxyCommand=ssh -i $pem -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -W %h:%p ubuntu@$bastion" core@$ip "$@" 2> >(grep -v "Warning: Permanently added .* to the list of known hosts\.")
+}
+
+pushd "$KUBIFY_STATE_PATH" 1> /dev/null
+ip=$(getIP master_ips 0)
+bastion=$(getIP bastion 0)
+pem=$KUBIFY_STATE_PATH/gen/nodes_privatekey.pem
+popd 1> /dev/null
+
+if [ $# -gt 0 ] && [ $1 == "start" ] ; then
+    debug "Starting bootstrap apiserver ..."
+    doSSH "sudo cp -r -f /opt/bootkube/assets/tls/ /etc/kubernetes/bootstrap-secrets"
+    doSSH "sudo cp -f /opt/bootkube/assets/bootstrap-manifests/bootstrap-apiserver.yaml /etc/kubernetes/manifests/"
+    debug "Bootstrap apiserver started."
+elif [ $# -gt 0 ] && [ $1 == "stop" ] ; then
+    debug "Stopping bootstrap apiserver ..."
+    doSSH "sudo rm -f /etc/kubernetes/manifests/bootstrap-apiserver.yaml"
+    doSSH "sudo rm -rf /etc/kubernetes/bootstrap-secrets"
+    debug "Bootstrap apiserver stopped."
+else 
+    fail "Invalid arguments! The bootstrap_apiserver script expects 'start' or 'stop' as parameter!"
+fi

--- a/components/certmanager/deploy
+++ b/components/certmanager/deploy
@@ -14,6 +14,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+wait_for_apiserver() {
+    debug "Checking if apiserver is ready ..."
+    uptodate=$(kubectl -n kube-system get ds kube-apiserver -o jsonpath='{.status.updatedNumberScheduled}')
+    ready=$(kubectl -n kube-system get ds kube-apiserver -o jsonpath='{.status.numberReady}')
+    while [[ $uptodate -lt 1 ]] || [[ $ready -lt 1 ]] ; do
+        # wait until new apiserver is ready
+        debug "Waiting until apiserver is ready ..."
+        sleep 10
+        uptodate=$(kubectl -n kube-system get ds kube-apiserver -o jsonpath='{.status.updatedNumberScheduled}')
+        ready=$(kubectl -n kube-system get ds kube-apiserver -o jsonpath='{.status.numberReady}')
+    done
+}
+
+# test if there is only one master node
+if [ $(kubectl get nodes --selector='node-role.kubernetes.io/master=' --no-headers | wc -l) -le 1 ] ; then
+    single_master="yes"
+else 
+    single_master="" # empty string is evaluated to false in test statement
+fi
+
 if [ $# -gt 1 ] && [ $2 == "-u" -o $2 == "--uninstall" ]; then # uninstall certmanager
     # delete certmanager
     helm delete --purge cert-manager
@@ -33,7 +53,14 @@ if [ $# -gt 1 ] && [ $2 == "-u" -o $2 == "--uninstall" ]; then # uninstall certm
             ((pos=$pos+1)) # add 1 to position of apiserver line to compute patch position
         fi
         # patch line '--oidc-ca-file=/etc/kubernetes/secrets/ca.crt' into kube-apiserver again
+        if [ $single_master ] ; then
+            $COMPONENT_TEMPLATE_HOME/bootstrap_apiserver.sh start
+        fi
         kubectl -n kube-system patch ds kube-apiserver --type json -p='[{"op": "add", "path": "/spec/template/spec/containers/0/command/'$pos'", "value": "--oidc-ca-file=/etc/kubernetes/secrets/ca.crt"}]'
+        if [ $single_master ] ; then
+            wait_for_apiserver
+            $COMPONENT_TEMPLATE_HOME/bootstrap_apiserver.sh stop
+        fi
     fi
 
     # patch dashboard and ingress 
@@ -94,15 +121,6 @@ else
             -p="$(cat ${COMPONENT_TEMPLATE_HOME}/issuer-patch.yaml)"
     fi
 
-    # find position of the line '--oidc-ca-file=/etc/kubernetes/secrets/ca.crt' and save the array position of that entry within the yaml to variable
-    pos=$(kubectl -n kube-system get -o template ds kube-apiserver --template='{{range $i, $elem := (index .spec.template.spec.containers 0).command}}{{if eq $elem "--oidc-ca-file=/etc/kubernetes/secrets/ca.crt"}}{{$i}}{{end}}{{end}}')
-    if [ $pos ]; then
-        # delete that entry
-        kubectl -n kube-system patch ds kube-apiserver --type json -p='[{"op": "remove", "path": "/spec/template/spec/containers/0/command/'$pos'"}]'
-    else
-        echo "INFO: Line '--oidc-ca-file=/etc/kubernetes/secrets/ca.crt' not found in daemonset kube-apiserver."
-    fi
-
     # wait until secrets have been recreated
     max_retry_time=300
     retry_stop=$(($(date +%s) + max_retry_time))
@@ -117,5 +135,21 @@ else
     done
     if ! $success; then
         fail "Secrets gardener-dashboard-tls and identity-tls not created within $max_retry_time seconds!"
+    fi
+
+    # find position of the line '--oidc-ca-file=/etc/kubernetes/secrets/ca.crt' and save the array position of that entry within the yaml to variable
+    pos=$(kubectl -n kube-system get -o template ds kube-apiserver --template='{{range $i, $elem := (index .spec.template.spec.containers 0).command}}{{if eq $elem "--oidc-ca-file=/etc/kubernetes/secrets/ca.crt"}}{{$i}}{{end}}{{end}}')
+    if [ $pos ]; then
+        # delete that entry
+        if [ $single_master ] ; then
+            $COMPONENT_TEMPLATE_HOME/bootstrap_apiserver.sh start
+        fi
+        kubectl -n kube-system patch ds kube-apiserver --type json -p='[{"op": "remove", "path": "/spec/template/spec/containers/0/command/'$pos'"}]'
+        if [ $single_master ] ; then
+            wait_for_apiserver
+            $COMPONENT_TEMPLATE_HOME/bootstrap_apiserver.sh stop
+        fi
+    else
+        echo "INFO: Line '--oidc-ca-file=/etc/kubernetes/secrets/ca.crt' not found in daemonset kube-apiserver."
     fi
 fi


### PR DESCRIPTION
This fixes the certmanager's problem that a rolling update of the
kube-apiserver is not possible on a cluster with only one apiserver.
The solution is to reactivate the bootstrap apiserver that was used
to pull up the kube-apiserver in the first place. Then the patching
is done and afterwards the bootstrap apiserver is shut down again.
This happens automatically when the certmanager is deployed and
only one master is detected.