### PR TITLE
Simplify docker run bash script

### DIFF
--- a/docker_run.sh
+++ b/docker_run.sh
@@ -21,11 +21,11 @@ CURRENT_IMAGE_VERSION=$(<IMAGE_VERSION)
 IMAGE_NAME="eu.gcr.io/gardener-project/gardener/gardener-setup"
 
 # check if image exists - if not, pull from repo
-if ! docker images | grep $IMAGE_NAME | grep $CURRENT_IMAGE_VERSION &> /dev/null ; then
+if [ -z $(docker images --format "{{.ID}}" $IMAGE_NAME:$CURRENT_IMAGE_VERSION) ]; then
     # pull image
     echo "Image $IMAGE_NAME:$CURRENT_IMAGE_VERSION not found locally - pulling it from repository ..."
     docker pull "$IMAGE_NAME:$CURRENT_IMAGE_VERSION"
-fi 
+fi
 
 # Run the docker container with interactive shell, cd to the mounted folder, and source the init.sh file
 # the "&& bash" keeps the interactive mode of the docker container alive


### PR DESCRIPTION
Signed-off-by: Johannes M. Scheuermann <joh.scheuer@gmail.com>

Remove the need for the multiple grep commands and just use the built-in functionality of the docker cli (should also be a little bit more performant if you have a large number of images on your machine).